### PR TITLE
Update to make plugin work with GoCD 17.1 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-#Go Generic Artifactory Registry Poller
+# GoCD Generic Artifactory Registry Poller
 
-A [Go](http://www.go.cd) plugin that polls a Artifactory repository
+A [GoCD](https://www.go.cd) plugin that polls a Artifactory repository
 
 [![Build Status](https://travis-ci.org/varchev/go-generic-artifactory-poller.svg?branch=master)](https://travis-ci.org/varchev/go-generic-artifactory-poller)
 
 Introduction
 ------------
-This is a [package material](http://www.thoughtworks.com/products/docs/go/current/help/package_material.html) plugin for [Go](http://www.go.cd). It is currently capable of polling [Artifactory](http://www.jfrog.com/artifactory/) repositories.
+This is a [package material](https://docs.go.cd/current/extension_points/package_repository_extension.html) plugin for [GoCD](https://www.go.cd). It is currently capable of polling [Artifactory](https://www.jfrog.com/artifactory/) repositories.
 
-The behaviour and capabilities of the plugin are determined to a significant extent by that of the package material extension point in Go. Be sure to read the package material documentation before using this plugin.
+The behaviour and capabilities of the plugin are determined to a significant extent by that of the package material extension point in GoCD. Be sure to read the package material documentation before using this plugin.
 
-This plugin polls artifactory repositories using its [REST API](http://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API). It relies on the convention that version number is part of the file path.
+This plugin polls artifactory repositories using its [REST API](https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API). It relies on the convention that version number is part of the file path.
 
 Installation
 ------------
-Just drop [go-generic-artifactory-poller.jar](https://github.com/varchev/go-generic-artifactory-poller/releases) into plugins/external directory and restart Go. More details [here](http://www.thoughtworks.com/products/docs/go/current/help/plugin_user_guide.html)
+Just drop [go-generic-artifactory-poller.jar](https://github.com/varchev/go-generic-artifactory-poller/releases) into plugins/external directory and restart GoCD. More details [here](https://docs.go.cd/current/extension_points/plugin_user_guide.html)
 
 Repository definition
 ---------------------

--- a/ivy.xml
+++ b/ivy.xml
@@ -9,7 +9,7 @@
         <dependency org="junit" name="junit" rev="4.11"/>
         <dependency org="org.json" name="json" rev="20140107"/>
         <dependency org="org.mockito" name="mockito-all" rev="1.9.5"/> 
-        <dependency org="cd.go.plugin" name="go-plugin-api" rev="14.4.0"/>
-    
+        <dependency org="cd.go.plugin" name="go-plugin-api" rev="16.12.0"/>
+        <dependency org="cd.go.plugin" name="gocd-package-material-plugin-shim" rev="16.12.0"/>
     </dependencies>
 </ivy-module>

--- a/src/net/varchev/go/plugin/genericArtifactory/apimpl/GenericArtifactoryProvider.java
+++ b/src/net/varchev/go/plugin/genericArtifactory/apimpl/GenericArtifactoryProvider.java
@@ -3,7 +3,6 @@ package net.varchev.go.plugin.genericArtifactory.apimpl;
 import com.thoughtworks.go.plugin.api.annotation.Extension;
 import com.thoughtworks.go.plugin.api.material.packagerepository.PackageMaterialProvider;
 
-@Extension
 public class GenericArtifactoryProvider implements PackageMaterialProvider {
 
     public PluginConfig getConfig() {

--- a/src/net/varchev/go/plugin/genericArtifactory/apimpl/NewPackageMaterialProvider.java
+++ b/src/net/varchev/go/plugin/genericArtifactory/apimpl/NewPackageMaterialProvider.java
@@ -1,0 +1,33 @@
+package net.varchev.go.plugin.genericArtifactory.apimpl;
+
+import com.thoughtworks.go.plugin.api.GoApplicationAccessor;
+import com.thoughtworks.go.plugin.api.GoPlugin;
+import com.thoughtworks.go.plugin.api.GoPluginIdentifier;
+import com.thoughtworks.go.plugin.api.annotation.Extension;
+import com.thoughtworks.go.plugin.api.exceptions.UnhandledRequestTypeException;
+import com.thoughtworks.go.plugin.api.material.packagerepository.shim.ReplacementProvider;
+import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
+import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+
+@Extension
+public class NewPackageMaterialProvider implements GoPlugin {
+    private ReplacementProvider replacementProvider;
+
+    public NewPackageMaterialProvider() {
+        replacementProvider = new ReplacementProvider(new GenericArtifactoryProvider());
+    }
+
+    @Override
+    public GoPluginApiResponse handle(GoPluginApiRequest goPluginApiRequest) throws UnhandledRequestTypeException {
+        return replacementProvider.handle(goPluginApiRequest);
+    }
+
+    @Override
+    public GoPluginIdentifier pluginIdentifier() {
+        return replacementProvider.pluginIdentifier();
+    }
+
+    @Override
+    public void initializeGoApplicationAccessor(GoApplicationAccessor goApplicationAccessor) {
+    }
+}


### PR DESCRIPTION
Using the [plugin shim](https://github.com/gocd-contrib/gocd-package-material-plugin-shim) to upgrade this plugin, so that it works with 17.1. Without this change, this plugin will stop working from GoCD 17.1 onwards.