### PR TITLE
Fixed incorrect material datetime bug

### DIFF
--- a/src/net/varchev/go/plugin/genericArtifactory/GenericArtifactoryUtils.java
+++ b/src/net/varchev/go/plugin/genericArtifactory/GenericArtifactoryUtils.java
@@ -1,0 +1,61 @@
+package net.varchev.go.plugin.genericArtifactory;
+
+import com.thoughtworks.go.plugin.api.logging.Logger;
+import com.tw.go.plugin.util.HttpRepoURL;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.params.CoreConnectionPNames;
+import org.apache.http.util.EntityUtils;
+import org.json.JSONObject;
+
+import java.util.Date;
+
+public class GenericArtifactoryUtils {
+    private static Logger LOGGER = Logger.getLoggerFor(GenericArtifactoryFeedDocument.class);
+
+    public GenericArtifactoryUtils() {
+
+    }
+
+    Date getLastUpdatedDate(String url) {
+        JSONObject itemInfo = getJsonObject(url);
+        String time = itemInfo.getString("lastUpdated");
+        return javax.xml.bind.DatatypeConverter.parseDateTime(time).getTime();
+    }
+
+    JSONObject getJsonObject(String url) {
+        DefaultHttpClient client = HttpRepoURL.getHttpClient();
+        HttpGet method = new HttpGet(url);
+        method.getParams().setParameter(CoreConnectionPNames.SO_TIMEOUT, 10 * 1000);
+        try {
+            HttpResponse response = client.execute(method);
+            if(response.getStatusLine().getStatusCode() == 404) {
+                throw new GenericArtifactoryException("No such package found");
+            }
+            else if(response.getStatusLine().getStatusCode() != 200){
+                throw new RuntimeException(String.format("HTTP %s, %s",
+                        response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase()));
+            }
+
+            HttpEntity entity = response.getEntity();
+            String responseBody = EntityUtils.toString(entity);
+
+            LOGGER.info(responseBody);
+
+            JSONObject result = new JSONObject(responseBody);
+
+            return result;
+        } catch (GenericArtifactoryException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            String message = String.format("%s (%s) while getting package feed for : %s ", ex.getClass().getSimpleName(), ex.getMessage(), url);
+            LOGGER.error(message);
+            throw new RuntimeException(message, ex);
+        } finally {
+            method.releaseConnection();
+            client.getConnectionManager().shutdown();
+        }
+    }
+}

--- a/src/net/varchev/go/plugin/genericArtifactory/apimpl/GenericArtifactoryPoller.java
+++ b/src/net/varchev/go/plugin/genericArtifactory/apimpl/GenericArtifactoryPoller.java
@@ -10,6 +10,7 @@ import com.thoughtworks.go.plugin.api.response.validation.ValidationError;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import net.varchev.go.plugin.genericArtifactory.GenericArtifactoryFeedDocument;
 import net.varchev.go.plugin.genericArtifactory.GenericArtifactoryParams;
+import net.varchev.go.plugin.genericArtifactory.GenericArtifactoryUtils;
 import net.varchev.go.plugin.genericArtifactory.config.GenericArtifactoryPackageConfig;
 import net.varchev.go.plugin.genericArtifactory.config.GenericArtifactoryRepoConfig;
 import com.tw.go.plugin.util.Credentials;
@@ -19,6 +20,12 @@ import org.json.JSONObject;
 
 public class GenericArtifactoryPoller implements PackageMaterialPoller {
     private static Logger LOGGER = Logger.getLoggerFor(GenericArtifactoryPoller.class);
+
+    private final GenericArtifactoryUtils utils;
+
+    public GenericArtifactoryPoller() {
+        utils = new GenericArtifactoryUtils();
+    }
 
     public PackageRevision getLatestRevision(PackageConfiguration packageConfig, RepositoryConfiguration repoConfig) {
         LOGGER.info(String.format("getLatestRevision called with packageName %s, for repo: %s",
@@ -128,7 +135,7 @@ public class GenericArtifactoryPoller implements PackageMaterialPoller {
         String url = params.getQuery();
         LOGGER.info(String.format("params received: %s", params.toString()));
 
-        GenericArtifactoryFeedDocument artifactoryFeedDocument = new GenericArtifactoryFeedDocument(url, params);
+        GenericArtifactoryFeedDocument artifactoryFeedDocument = new GenericArtifactoryFeedDocument(url, params, utils);
         PackageRevision packageRevision = artifactoryFeedDocument.getPackageRevision(params.isLastVersionKnown());
         if(packageRevision != null && params.getRepoUrl().getCredentials().provided())
         {

--- a/test/fast/artifactory-item-good-feed.json
+++ b/test/fast/artifactory-item-good-feed.json
@@ -1,0 +1,21 @@
+{
+  "repo" : "repo-id",
+  "path" : "/Path/To/Artifact",
+  "created" : "2016-09-13T12:09:31.472+03:00",
+  "createdBy" : "userName",
+  "lastModified" : "2016-09-13T12:29:51.341+03:00",
+  "modifiedBy" : "userName",
+  "lastUpdated" : "2016-09-13T12:29:51.341+03:00",
+  "downloadUri" : "https://artifactory.example.com/artifactory/storage/repo-id/Path/To/Artifact/Artifact.1.8.26.1.zip",
+  "mimeType" : "application/zip",
+  "size" : "394127082",
+  "checksums" : {
+    "sha1" : "526069b96abefa71cb243de2c5180db1621a1e8e",
+    "md5" : "1442339d95be0311b9146ea3d67d09f7"
+  },
+  "originalChecksums" : {
+    "sha1" : "526069b96abefa71cb243de2c5180db1621a1e8e",
+    "md5" : "1442339d95be0311b9146ea3d67d09f7"
+  },
+  "uri" : "https://artifactory.example.com/artifactory/api/storage/repo-id/Path/To/Artifact/Artifact.1.8.26.1.zip"
+}

--- a/test/fast/net/varchev/go/plugin/genericArtifactory/GenericArtifactoryFeedDocumentTest.java
+++ b/test/fast/net/varchev/go/plugin/genericArtifactory/GenericArtifactoryFeedDocumentTest.java
@@ -11,22 +11,26 @@ import java.io.File;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.mockito.Mockito.*;
+
 
 public class GenericArtifactoryFeedDocumentTest {
+    private static final String BASE_URL = "http://artifactory.example.com/artifactory";
 
     @Test
     public void shouldCreatePackageRevision() throws Exception {
-        String fileContent = FileUtils.readFileToString(new File("test" + File.separator + "fast" + File.separator + "artifactory-good-feed.json"));
-        JSONObject doc = new JSONObject(fileContent);
-
-        GenericArtifactoryParams params = new GenericArtifactoryParams(RepoUrl.create("http://artifactory.example.com/artifactory", null, null),
+        GenericArtifactoryUtils mockUtils = mock(GenericArtifactoryUtils.class);
+        String itemUpdatedTime = "2016-09-13T12:29:51.341+03:00";
+        when(mockUtils.getLastUpdatedDate(anyString())).thenReturn(javax.xml.bind.DatatypeConverter.parseDateTime((itemUpdatedTime)).getTime());
+        GenericArtifactoryParams params = new GenericArtifactoryParams(RepoUrl.create(BASE_URL, null, null),
                 "repo-id", "Path/To/Artifact", "Artifact", "1.7", null, null);
-        PackageRevision result = new GenericArtifactoryFeedDocument(doc,params).getPackageRevision(false);
+        String fileContent = FileUtils.readFileToString(new File("test" + File.separator + "fast" + File.separator + "artifactory-good-feed.json"));
+        when(mockUtils.getJsonObject(params.getQuery())).thenReturn(new JSONObject(fileContent));
+        PackageRevision result = new GenericArtifactoryFeedDocument(params.getQuery(), params, mockUtils).getPackageRevision(false);
+
         assertThat(result.getUser(), is("userName"));
         assertThat(result.getRevision(), is("1.8.26.1"));
-
-        assertThat(result.getTimestamp(), is(javax.xml.bind.DatatypeConverter.parseDateTime(("2014-08-27T10:40:47.567+03:00")).getTime()));
+        assertThat(result.getTimestamp(), is(javax.xml.bind.DatatypeConverter.parseDateTime((itemUpdatedTime)).getTime()));
         assertThat(result.getDataFor(GenericArtifactoryPackageConfig.PACKAGE_LOCATION), is("http://artifactory.example.com/artifactory/repo-id/Path/To/Artifact/Artifact.1.8.26.1.zip"));
         assertThat(result.getDataFor(GenericArtifactoryPackageConfig.PACKAGE_VERSION), is("1.8.26.1"));
     }

--- a/test/fast/net/varchev/go/plugin/genericArtifactory/GenericArtifactoryUtilsTest.java
+++ b/test/fast/net/varchev/go/plugin/genericArtifactory/GenericArtifactoryUtilsTest.java
@@ -1,0 +1,39 @@
+package net.varchev.go.plugin.genericArtifactory;
+
+import org.apache.commons.io.FileUtils;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import javax.xml.bind.DatatypeConverter;
+import java.io.File;
+import java.util.Date;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+public class GenericArtifactoryUtilsTest {
+    private static final String REPO_URL = "https://artifactory.example.com/artifactory/api/storage/repo-id/Path/To/Artifact";
+    private static final String ITEM_URL = "https://artifactory.example.com/artifactory/api/storage/repo-id/Path/To/Artifact/Artifact.1.8.26.1.zip";
+    private static final String ITEM_UPDATED_DATE = "2016-09-13T12:29:51.341+03:00";
+    private static final String REPO_UPDATED_DATE = "2014-08-27T10:40:47.567+03:00";
+    private static final String BASE_TEST_FILE_PATH = "test" + File.separator + "fast" + File.separator;
+
+    @Test
+    public void shouldParseAndReturnLastUpdatedDate() throws Exception {
+        GenericArtifactoryUtils utils = spy(new GenericArtifactoryUtils());
+        String repoFeedFile = FileUtils.readFileToString(new File(BASE_TEST_FILE_PATH + "artifactory-good-feed.json"));
+        doReturn(new JSONObject(repoFeedFile)).when(utils).getJsonObject(REPO_URL);
+        String itemFeedFile = FileUtils.readFileToString(new File(BASE_TEST_FILE_PATH + "artifactory-item-good-feed.json"));
+        doReturn(new JSONObject(itemFeedFile)).when(utils).getJsonObject(ITEM_URL);
+
+        Date repoDate = utils.getLastUpdatedDate(REPO_URL);
+        Date lastItemDate = utils.getLastUpdatedDate(ITEM_URL);
+
+        assertThat(lastItemDate, is(DatatypeConverter.parseDateTime((ITEM_UPDATED_DATE)).getTime()));
+        assertThat(repoDate, is(DatatypeConverter.parseDateTime(REPO_UPDATED_DATE).getTime()));
+
+
+    }
+}


### PR DESCRIPTION
Current implementation read last updated date of repository folder and use it for package revision timestamp. So material timestamp for a repository is always same though package version has been updated, and it causes misleading sometimes.

This commit updated GenericArtifactoryFeedDocument to get last updated time of latest child item and then use it for package revision timestamp. And extracted some static methods and made them as separated class for a convenience of unit tests. And then added more test resource file and test case to test this case.